### PR TITLE
Also need synchronize trigger; GitHub discards old statuses on new commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your GitHub project by creating `.github/workflows/task-list-checker
 name: GitHub Task List Checker
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize, reopened]
 jobs:
   task-list-checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We discovered on the [Shop Pay integration PR](https://github.com/Shopify/pay/pull/11094) that we need a `synchronize` trigger also. 

Since GitHub groups statuses by commit, pushing up a new commit causes it to forget old statuses. So any time there's a change in commits, we need to force a re-run of this task to re-apply the 🟡 Pending status.