### PR TITLE
Upgrade action to use node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: "https://github.com/Shopify/task-list-checker#in-a-pull-request"
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
Fixes this warning when the action is run:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: Shopify/task-list-checker@main.

More info: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/