### PR TITLE
Revert "Upgrade action to use node v16"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
     default: "https://github.com/Shopify/task-list-checker#in-a-pull-request"
 runs:
-  using: "node16"
+  using: "node12"
   main: "index.js"


### PR DESCRIPTION
Reverts Shopify/task-list-checker#9 See discussion there, and https://github.com/Shopify/pay/pull/20282